### PR TITLE
fix cgo builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Accept the Go version for the image to be set as a build argument.
 # Default to Go 1.11
-ARG GO_VERSION=1.11
+ARG GO_VERSION=1.12
 
 # First stage: build the executable.
-FROM golang:${GO_VERSION}-alpine AS builder
+FROM golang:${GO_VERSION}-stretch AS builder
 
 # What arch is it?
 ARG GOARCH=amd64
@@ -11,7 +11,8 @@ ARG GOOS=linux
 
 # Install the Certificate-Authority certificates for the app to be able to make
 # calls to HTTPS endpoints.
-RUN apk add --no-cache ca-certificates git gcc libc-dev
+RUN apt-get update && \
+    apt-get install -y ca-certificates git gcc libc-dev libncurses5-dev
 
 # Set the environment variables for the go command:
 # * GOFLAGS=-mod=vendor to force `go build` to look into the `/vendor` folder.
@@ -27,10 +28,7 @@ COPY ./ ./
 RUN echo "Building for $GOARCH" \
     && mkdir -p ${GOPATH}/src/github.com/kubernetes-sigs \
     && ln -sf `pwd` ${GOPATH}/src/github.com/kubernetes-sigs/dashboard-metrics-scraper \
-    && GOARCH=${GOARCH} go build \
-    -installsuffix 'static' \
-    -ldflags '-extldflags "-static"' \
-    -o /metrics-sidecar github.com/kubernetes-sigs/dashboard-metrics-scraper
+    && GOARCH=${GOARCH} hack/build.sh 
 
 # Final stage: the running container.
 FROM scratch AS final

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [[ "$GOARCH" = "arm" ]]; then
+
+echo "Detected ARM. Setting additional variables.";
+
+apt-get install -y libc6-armel-cross libc6-dev-armel-cross binutils-arm-linux-gnueabi gcc-arm-linux-gnueabihf
+
+env CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ \
+CGO_ENABLED=1 GOOS=linux GOARM=7 \
+go build \
+-installsuffix 'static' \
+-ldflags '-extldflags "-static"' \
+-o /metrics-sidecar github.com/kubernetes-sigs/dashboard-metrics-scraper
+
+else
+
+echo "Build script building for ${GOARCH}";
+
+go build \
+-installsuffix 'static' \
+-ldflags '-extldflags "-static"' \
+-o /metrics-sidecar github.com/kubernetes-sigs/dashboard-metrics-scraper
+
+fi


### PR DESCRIPTION
We can't use alpine as a build container as we need to install additional libraries to cross-compile the `sqlite-go` library due to `cgo`

This uses the `stretch` image and when it detects the build is for `arm` it pulls the additional dependencies and does the build.

Tested this locally on an rpi3 and tested images I pushed to a local repo.