### PR TITLE
change to nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,16 @@ FROM scratch AS final
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Import the compiled executable from the second stage.
-COPY --from=builder /metrics-sidecar /metrics-sidecar
+COPY --chown=1501:1501 --from=builder /metrics-sidecar /metrics-sidecar
 
 # We need a tmp folder too
-COPY --from=builder /tmp /tmp
+COPY --chown=1501:1501 --from=builder /tmp /tmp
 
 # Declare the port on which the webserver will be exposed.
 EXPOSE 8080
+
+# Run as a non-root UID
+USER 1501
 
 # Run the compiled binary.
 ENTRYPOINT ["/metrics-sidecar"]


### PR DESCRIPTION
Fix for https://github.com/kubernetes-sigs/dashboard-metrics-scraper/issues/16

Run as 1501 by default, which is not the root user.  More importantly 1501 needs to be able to write to /tmp, which wasn't working before.  I'm actually not sure it needs to own the binary as well, but just adding as a safe measure.  Using the --chown arg to these two COPY lines just seemed like the simplest non-invasive way to make the change.