### PR TITLE
Enable CGO for ARM64

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,6 +13,19 @@ go build \
 -ldflags '-extldflags "-static"' \
 -o /metrics-sidecar github.com/kubernetes-sigs/dashboard-metrics-scraper
 
+elif [[ "$GOARCH" = "arm64" ]]; then
+
+echo "Detected ARM64. Setting additional variables.";
+
+apt-get install -y gcc-aarch64-linux-gnu
+
+env CC=aarch64-linux-gnu-gcc \
+CGO_ENABLED=1 GOOS=linux \
+go build \
+-installsuffix 'static' \
+-ldflags '-extldflags "-static"' \
+-o /metrics-sidecar github.com/kubernetes-sigs/dashboard-metrics-scraper
+
 else
 
 echo "Build script building for ${GOARCH}";


### PR DESCRIPTION
Enabling CGO build for arm64.

Addressing [kubernetes-metrics-scraper on ARM on 2.0beta1: Unable to initialize database tables: Binary was compiled with 'CGO_ENABLED=0]( https://github.com/kubernetes/dashboard/issues/4029)

Tested the resulting image on my Rock64 Kuberntes cluster - works as expected.