### PR TITLE
Enable CGO support for s390x platform

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -26,6 +26,18 @@ go build \
 -ldflags '-extldflags "-static"' \
 -o /metrics-sidecar github.com/kubernetes-sigs/dashboard-metrics-scraper
 
+elif [[ "$GOARCH" = "s390x" ]]; then
+
+echo "Detected s390x. Setting additional variables.";
+
+apt-get install -y gcc-s390x-linux-gnu
+
+env CC=s390x-linux-gnu-gcc \
+CGO_ENABLED=1 GOOS=linux \
+go build \
+-installsuffix 'static' \
+-ldflags '-extldflags "-static"' \
+-o /metrics-sidecar github.com/kubernetes-sigs/dashboard-metrics-scraper
 else
 
 echo "Build script building for ${GOARCH}";


### PR DESCRIPTION
Similar to #19 . 
Fix `{"level":"fatal","msg":"Unable to initialize database tables: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub","time":"2019-07-07T18:52:32Z"}` error on s390x platform.