### PR TITLE
Add GitHub workflows

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,7 +16,7 @@ name: Continuous Integration - Code
 
 on:
   push:
-    branches: [ master, github-workflows ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,115 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Continuous Integration - Code
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check:
+    name: Static Check
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+      GOPROXY: "https://proxy.golang.org"
+      TERM: xterm
+    steps:
+      - name: Setup Environment
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.1
+
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          command -v golangci-lint >/dev/null 2>&1 || { curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0; } && go mod download
+      
+      - name: Run vet & lint
+        run: |
+          go vet .
+          golint .
+
+      - name: Check Code
+        shell: bash
+        run: |
+          export GOPATH=$(go env GOPATH)/bin
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+      GOPROXY: "https://proxy.golang.org"
+      TERM: xterm
+
+    steps:
+      - name: Setup Environment
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.1
+
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          command -v golangci-lint >/dev/null 2>&1 || { curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0; } && go mod download
+      
+      - name: Run Go test
+        run: go test ./...
+
+      - name: Cleanup & Upload Coverage
+        shell: bash
+        run: |
+          rm -rf .tmp
+          bash <(curl -s https://codecov.io/bash) -c -K || echo "Codecov upload failed"
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+      GOPROXY: "https://proxy.golang.org"
+      TERM: xterm
+
+    steps:
+      - name: Setup Environment
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.1
+
+      - name: Install Dependencies
+        shell: bash
+        run: |
+          command -v golangci-lint >/dev/null 2>&1 || { curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0; } && go mod download
+
+      - name: Run build
+        run: go build .

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -16,7 +16,7 @@ name: Continuous Integration - Code
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, github-workflows ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run vet & lint
         run: |
           go vet .
-          golint .
+          golangci-lint .
 
       - name: Check Code
         shell: bash
@@ -88,7 +88,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -c -K || echo "Codecov upload failed"
 
   build:
-    name: build
+    name: Build
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run vet & lint
         run: |
           go vet .
-          golangci-lint .
+          golangci-lint run
 
       - name: Check Code
         shell: bash

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
 	golang.org/x/oauth2 v0.0.0-20170412232759-a6bd8cefa181 // indirect
 	golang.org/x/time v0.0.0-20161028155119-f51c12702a4d // indirect
-	google.golang.org/appengine v1.4.0 // indirect
+	google.golang.org/appengine v1.4.0
 	gopkg.in/fsnotify/fsnotify.v1 v1.4.7 // indirect
 	gopkg.in/inf.v0 v0.9.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,8 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// APIManager provides a handler for all api calls
-func APIManager(r *mux.Router, db *sql.DB) {
+// Manager provides a handler for all api calls
+func Manager(r *mux.Router, db *sql.DB) {
 	dashboardRouter := r.PathPrefix("/api/v1/dashboard").Subrouter()
 	dashboardProvider.DashboardRouter(dashboardRouter, db)
 	r.PathPrefix("/").HandlerFunc(DefaultHandler)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -8,15 +8,21 @@ import (
 	"github.com/gorilla/mux"
 	dashboardProvider "github.com/kubernetes-sigs/dashboard-metrics-scraper/pkg/api/dashboard"
 	_ "github.com/mattn/go-sqlite3"
+	log "github.com/sirupsen/logrus"
 )
 
+// APIManager provides a handler for all api calls
 func APIManager(r *mux.Router, db *sql.DB) {
 	dashboardRouter := r.PathPrefix("/api/v1/dashboard").Subrouter()
 	dashboardProvider.DashboardRouter(dashboardRouter, db)
 	r.PathPrefix("/").HandlerFunc(DefaultHandler)
 }
 
+// DefaultHandler provides a handler for all http calls
 func DefaultHandler(w http.ResponseWriter, r *http.Request) {
 	msg := fmt.Sprintf("URL: %s", r.URL)
-	w.Write([]byte(msg))
+	_, err := w.Write([]byte(msg))
+	if err != nil {
+		log.Errorf("Error cannot write response: %v", err)
+	}
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -79,6 +79,9 @@ func UpdateDatabase(db *sql.DB, nodeMetrics *v1beta1.NodeMetricsList, podMetrics
 */
 func CullDatabase(db *sql.DB, window *time.Duration) error {
 	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
 
 	windowStr := fmt.Sprintf("-%.0f seconds", window.Seconds())
 
@@ -97,6 +100,9 @@ func CullDatabase(db *sql.DB, window *time.Duration) error {
 	log.Debugf("Cleaning up nodes: %d rows removed", affected)
 
 	podstmt, err := tx.Prepare("delete from pods where time <= datetime('now', ?);")
+	if err != nil {
+		return err
+	}
 
 	defer podstmt.Close()
 	res, err = podstmt.Exec(windowStr)

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -70,7 +70,10 @@ var _ = Describe("Database functions", func() {
 
 			defer db.Close()
 
-			sideDb.CreateDatabase(db)
+			err = sideDb.CreateDatabase(db)
+			if err != nil {
+				panic(err.Error())
+			}
 
 			_, err = db.Query("select * from nodes;")
 			if err != nil {
@@ -86,7 +89,10 @@ var _ = Describe("Database functions", func() {
 			}
 			defer db.Close()
 
-			sideDb.CreateDatabase(db)
+			err = sideDb.CreateDatabase(db)
+			if err != nil {
+				panic(err.Error())
+			}
 
 			_, err = db.Query("select * from pods;")
 			if err != nil {
@@ -102,12 +108,18 @@ var _ = Describe("Database functions", func() {
 			}
 			defer db.Close()
 
-			sideDb.CreateDatabase(db)
+			err = sideDb.CreateDatabase(db)
+			if err != nil {
+				panic(err.Error())
+			}
 
 			nm := nodeMetrics()
 			pm := podMetrics()
 
-			sideDb.UpdateDatabase(db, &nm, &pm)
+			err = sideDb.UpdateDatabase(db, &nm, &pm)
+			if err != nil {
+				panic(err.Error())
+			}
 
 			rows, err := db.Query("select name, cpu, memory from nodes")
 			if err != nil {
@@ -168,7 +180,10 @@ var _ = Describe("Database functions", func() {
 			nm := nodeMetrics()
 			pm := podMetrics()
 
-			sideDb.UpdateDatabase(db, &nm, &pm)
+			err = sideDb.UpdateDatabase(db, &nm, &pm)
+			if err != nil {
+				panic(err.Error())
+			}
 
 			sqlStmt := "insert into nodes(name,cpu,memory,storage,time) values('lame','1000','100000','0',datetime('now','-20 minutes'));"
 			_, err = db.Exec(sqlStmt)
@@ -177,7 +192,14 @@ var _ = Describe("Database functions", func() {
 			}
 
 			timeWindow, err := time.ParseDuration("5m")
-			sideDb.CullDatabase(db, &timeWindow)
+			if err != nil {
+				panic(err.Error())
+			}
+
+			err = sideDb.CullDatabase(db, &timeWindow)
+			if err != nil {
+				panic(err.Error())
+			}
 
 			rows, err := db.Query("select name, cpu, memory from nodes")
 			if err != nil {

--- a/server.go
+++ b/server.go
@@ -92,7 +92,7 @@ func main() {
 	go func() {
 		r := mux.NewRouter()
 
-		sideapi.APIManager(r, db)
+		sideapi.Manager(r, db)
 		// Bind to a port and pass our router in
 		log.Fatal(http.ListenAndServe(":8000", handlers.CombinedLoggingHandler(os.Stdout, r)))
 	}()

--- a/server.go
+++ b/server.go
@@ -48,7 +48,10 @@ func main() {
 	// When running in a scoped namespace, disable Node lookup and only capture metrics for the given namespace(s)
 	metricNamespace = flag.StringSliceP("namespace", "n", []string{getEnv("POD_NAMESPACE", "")}, "The namespace to use for all metric calls. When provided, skip node metrics. (defaults to cluster level metrics)")
 
-	flag.Set("logtostderr", "true")
+	err := flag.Set("logtostderr", "true")
+	if err != nil {
+		log.Errorf("Error cannot set logtostderr: %v", err)
+	}
 	flag.Parse()
 
 	level, err := log.ParseLevel(*logLevel)
@@ -159,16 +162,6 @@ func update(client *metricsclient.Clientset, db *sql.DB, metricDuration *time.Du
 
 	log.Infof("Database updated: %d nodes, %d pods", len(nodeMetrics.Items), len(podMetrics.Items))
 	return nil
-}
-
-/**
-* Lookup the user home directory respective of the OS
- */
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
-	}
-	return os.Getenv("USERPROFILE") // windows
 }
 
 /**


### PR DESCRIPTION
Add Github actions for master & PR
* Run tests
* Run vet/lint
* Run build

This lead to linter complaining about a few missing things, that needed to be changed
```bash
server.go:142:6: `homeDir` is unused (deadcode)
func homeDir() string {
     ^
pkg/api/dashboard/dashboard.go:26:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write([]byte(msg))
	       ^
pkg/api/dashboard/dashboard.go:40:11: Error return value of `w.Write` is not checked (errcheck)
			w.Write([]byte(fmt.Sprintf("Node Metrics Error - %v", err.Error())))
			       ^
pkg/api/dashboard/dashboard.go:47:11: Error return value of `w.Write` is not checked (errcheck)
			w.Write([]byte(fmt.Sprintf("JSON Error - %v", err.Error())))
			       ^
pkg/database/database_test.go:73:25: Error return value of `sideDb.CreateDatabase` is not checked (errcheck)
			sideDb.CreateDatabase(db)
			                     ^
pkg/database/database_test.go:89:25: Error return value of `sideDb.CreateDatabase` is not checked (errcheck)
			sideDb.CreateDatabase(db)
			                     ^
pkg/database/database_test.go:105:25: Error return value of `sideDb.CreateDatabase` is not checked (errcheck)
			sideDb.CreateDatabase(db)
			                     ^
pkg/database/database_test.go:110:25: Error return value of `sideDb.UpdateDatabase` is not checked (errcheck)
			sideDb.UpdateDatabase(db, &nm, &pm)
			                     ^
pkg/database/database_test.go:171:25: Error return value of `sideDb.UpdateDatabase` is not checked (errcheck)
			sideDb.UpdateDatabase(db, &nm, &pm)
			                     ^
pkg/database/database_test.go:180:23: Error return value of `sideDb.CullDatabase` is not checked (errcheck)
			sideDb.CullDatabase(db, &timeWindow)
			                   ^
server.go:47:10: Error return value of `flag.Set` is not checked (errcheck)
	flag.Set("logtostderr", "true")
	        ^
pkg/api/dashboard/dashboard.go:92:3: ineffectual assignment to `metricName` (ineffassign)
		metricName = "memory"
		^
pkg/api/dashboard/dashboard.go:161:6: ineffectual assignment to `err` (ineffassign)
		v, err := strconv.ParseUint(metricValue, 10, 64)
		   ^
pkg/database/database.go:81:6: ineffectual assignment to `err` (ineffassign)
	tx, err := db.Begin()
	    ^
pkg/database/database.go:99:11: ineffectual assignment to `err` (ineffassign)
	podstmt, err := tx.Prepare("delete from pods where time <= datetime('now', ?);")
	         ^
pkg/database/database.go:101:2: SA5001: should check returned error before deferring podstmt.Close() (staticcheck)
	defer podstmt.Close()
	^
pkg/database/database_test.go:179:4: SA4006: this value of `err` is never used (staticcheck)
			timeWindow, err := time.ParseDuration("5m")
			^
```