### PR TITLE
Use buildx for cross-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 ARG GO_VERSION=1.18
 
 # First stage: build the executable.
-FROM golang:${GO_VERSION}-stretch AS builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-stretch AS builder
 
 # What arch is it?
-ARG GOARCH=amd64
-ARG GOOS=linux
+ARG GOARCH=$TARGETARCH
+ARG GOOS=$TARGETOS
 
 # Install the Certificate-Authority certificates for the app to be able to make
 # calls to HTTPS endpoints.

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,33 +1,12 @@
 #!/bin/bash
 
-arch_list="amd64 arm arm64 ppc64le s390x"
+arch_list=(amd64 arm arm64 ppc64le s390x)
 manifest="kubernetesui/metrics-scraper";
-manifest_list="";
 
+# Concat arch_list with ,
+platforms=$(IFS=,; echo "${arch_list[*]}")
 
-for i in ${arch_list}; do
-    # If it's a tagged release, use the tag
-    # Otherwise, assume it's HEAD and push to latest
-    container="${manifest}-${i}:${TRAVIS_TAG:="latest"}"
+image_name="${manifest}:${TRAVIS_TAG:="latest"}"
 
-    echo "--- docker build --no-cache --build-arg GOARCH=${i} -t ${container} .";
-    docker build --no-cache --build-arg GOARCH=${i} -t ${container} .
-
-    echo "--- docker push ${container}"
-    docker push ${container}
-
-    manifest_list="${manifest_list} ${container}"
-done;
-
-echo "--- docker manifest create --amend ${manifest}:${TRAVIS_TAG:="latest"} ${manifest_list}"
-docker manifest create --amend ${manifest}:${TRAVIS_TAG:="latest"} ${manifest_list}
-
-for i in ${arch_list}; do
-    container="${manifest}-${i}:${TRAVIS_TAG:="latest"}"
-
-    echo "--- docker manifest annotate ${manifest}:${TRAVIS_TAG:="latest"} ${container} --os linux --arch ${i}"
-    docker manifest annotate ${manifest}:${TRAVIS_TAG:="latest"} ${container} --os linux --arch ${i}
-done;
-
-echo "--- docker manifest push ${manifest}:${TRAVIS_TAG:="latest"}"
-docker manifest push ${manifest}:${TRAVIS_TAG:="latest"}
+echo "--- docker buildx build --push --platform $platforms --tag $image_name .";
+docker buildx build --push --platform ${platforms} --tag ${image_name} .


### PR DESCRIPTION
Use Docker buildx build tooling to create multi-arch manifest instead of manually adding images.

Test build:
https://hub.docker.com/r/jamesnelson/metrics-scraper/tags

Fixes: #54

Signed-off-by: James Tumber <james.tumber@ibm.com>